### PR TITLE
feat: persist playlist service and fix state ownership

### DIFF
--- a/src-tauri/src/api/playlist/mod.rs
+++ b/src-tauri/src/api/playlist/mod.rs
@@ -282,30 +282,12 @@ pub async fn reorder_playlist_tracks(
         "Failed to access playlists service".to_string()
     })?;
 
-    // Get the playlist
-    let playlist = playlists
-        .get_playlist_mut(&playlist_id)
-        .ok_or_else(|| "Playlist not found".to_string())?;
-
-    // Check bounds
-    if from_index >= playlist.track_ids.len() || to_index >= playlist.track_ids.len() {
-        return Err("Index out of bounds".to_string());
-    }
-
-    // Reorder tracks
-    if from_index < to_index {
-        // Move item to the right
-        for i in from_index..to_index {
-            playlist.track_ids.swap(i, i + 1);
-        }
-    } else if from_index > to_index {
-        // Move item to the left
-        for i in (to_index..from_index).rev() {
-            playlist.track_ids.swap(i, i + 1);
-        }
-    }
-
-    Ok(())
+    playlists
+        .reorder_playlist_tracks(&playlist_id, from_index, to_index)
+        .map_err(|e| {
+            error!("Failed to reorder playlist tracks: {}", e);
+            e
+        })
 }
 
 /// Get tracks in a playlist
@@ -363,18 +345,17 @@ pub async fn set_playlist_tracks(
         "Failed to access playlists service".to_string()
     })?;
 
-    let playlist = playlists
-        .get_playlist_mut(&playlist_id)
-        .ok_or_else(|| "Playlist not found".to_string())?;
-
     let parsed_ids: Result<Vec<Uuid>, String> = tracks
         .into_iter()
         .map(|id| Uuid::parse_str(&id).map_err(|e| format!("Invalid track ID: {}", e)))
         .collect();
 
-    playlist.track_ids = parsed_ids?;
-
-    Ok(())
+    playlists
+        .set_playlist_tracks(&playlist_id, parsed_ids?)
+        .map_err(|e| {
+            error!("Failed to set playlist tracks: {}", e);
+            e
+        })
 }
 
 /// Get the number of playlists

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,7 +37,11 @@ impl AppState {
                 services::library::LibraryService::new()
                     .context("Failed to initialize library service")?,
             )),
-            playlists: Arc::new(Mutex::new(services::playlist::PlaylistService::new())),
+            playlists: Arc::new(Mutex::new(
+                services::playlist::PlaylistService::new()
+                    .map_err(anyhow::Error::msg)
+                    .context("Failed to initialize playlist service")?,
+            )),
         })
     }
 }

--- a/src-tauri/src/models/playlist.rs
+++ b/src-tauri/src/models/playlist.rs
@@ -25,25 +25,21 @@ pub struct Playlist {
 
 impl Default for Playlist {
     fn default() -> Self {
-        let now = Utc::now();
-        Self {
-            id: Uuid::new_v4(),
-            name: "New Playlist".to_string(),
-            description: None,
-            track_ids: Vec::new(),
-            artwork: None,
-            created_at: now,
-            updated_at: now,
-        }
+        Self::with_id(Uuid::new_v4(), "New Playlist")
     }
 }
 
 impl Playlist {
     /// Create a new playlist with the given name
     pub fn new(name: &str) -> Self {
+        Self::with_id(Uuid::new_v4(), name)
+    }
+
+    /// Create a new playlist with an explicit identifier.
+    pub fn with_id(id: Uuid, name: &str) -> Self {
         let now = Utc::now();
         Self {
-            id: Uuid::new_v4(),
+            id,
             name: name.to_string(),
             description: None,
             track_ids: Vec::new(),

--- a/src-tauri/src/services/playlist/mod.rs
+++ b/src-tauri/src/services/playlist/mod.rs
@@ -1,22 +1,66 @@
 //! Playlist service for managing playlists
 
+mod store;
+
 use log::info;
 use std::collections::HashMap;
+use std::path::Path;
 use uuid::Uuid;
 
 use crate::models::Playlist;
 
+use self::store::PlaylistStore;
+
 /// Playlist service for managing playlists
-#[derive(Default)]
 pub struct PlaylistService {
+    store: PlaylistStore,
     playlists: HashMap<Uuid, Playlist>,
     playlist_names: HashMap<String, Uuid>,
 }
 
+impl Default for PlaylistService {
+    fn default() -> Self {
+        Self::open_in_memory().expect("in-memory playlist service should initialize")
+    }
+}
+
 impl PlaylistService {
-    /// Create a new PlaylistService
-    pub fn new() -> Self {
-        Self::default()
+    /// Create a new PlaylistService backed by the application data database.
+    pub fn new() -> Result<Self, String> {
+        let mut path = crate::utils::app_data_dir()
+            .ok_or_else(|| "Failed to locate app data directory".to_string())?;
+        crate::utils::ensure_dir_exists(&path)
+            .map_err(|e| format!("Failed to create app data directory {}: {e}", path.display()))?;
+        path.push("library.sqlite");
+        Self::open(&path)
+    }
+
+    /// Create a playlist service backed by the database at the provided path.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, String> {
+        let store = PlaylistStore::open(path.as_ref()).map_err(|e| e.to_string())?;
+        Self::from_store(store)
+    }
+
+    fn open_in_memory() -> Result<Self, String> {
+        let store = PlaylistStore::open_in_memory().map_err(|e| e.to_string())?;
+        Self::from_store(store)
+    }
+
+    fn from_store(store: PlaylistStore) -> Result<Self, String> {
+        let loaded = store.load_all().map_err(|e| e.to_string())?;
+        let mut playlists = HashMap::new();
+        let mut playlist_names = HashMap::new();
+
+        for playlist in loaded {
+            playlist_names.insert(playlist.name.to_lowercase(), playlist.id);
+            playlists.insert(playlist.id, playlist);
+        }
+
+        Ok(Self {
+            store,
+            playlists,
+            playlist_names,
+        })
     }
 
     /// Create a new playlist
@@ -25,17 +69,17 @@ impl PlaylistService {
             return Err("Playlist name cannot be empty".to_string());
         }
 
-        // Check if a playlist with this name already exists
         let key = name.to_lowercase();
         if self.playlist_names.contains_key(&key) {
             return Err(format!("A playlist named '{}' already exists", name));
         }
 
         let id = Uuid::new_v4();
-        let playlist = Playlist::new(name);
+        let playlist = Playlist::with_id(id, name);
 
-        self.playlists.insert(id, playlist);
+        self.store.save_playlist(&playlist).map_err(|e| e.to_string())?;
         self.playlist_names.insert(key, id);
+        self.playlists.insert(id, playlist);
 
         info!("Created playlist '{}' with ID: {}", name, id);
 
@@ -44,23 +88,27 @@ impl PlaylistService {
 
     /// Delete a playlist
     pub fn delete_playlist(&mut self, id: &Uuid) -> Result<(), String> {
-        if let Some(playlist) = self.playlists.remove(id) {
-            self.playlist_names.remove(&playlist.name.to_lowercase());
-            info!("Deleted playlist '{}' with ID: {}", playlist.name, id);
-            Ok(())
-        } else {
-            Err("Playlist not found".to_string())
-        }
+        let playlist = self
+            .playlists
+            .get(id)
+            .cloned()
+            .ok_or_else(|| "Playlist not found".to_string())?;
+
+        self.store.delete_playlist(id).map_err(|e| e.to_string())?;
+        self.playlists.remove(id);
+        self.playlist_names.remove(&playlist.name.to_lowercase());
+
+        info!("Deleted playlist '{}' with ID: {}", playlist.name, id);
+        Ok(())
     }
 
     /// Add a track to a playlist
     pub fn add_to_playlist(&mut self, playlist_id: &Uuid, track_id: Uuid) -> Result<(), String> {
-        if let Some(playlist) = self.playlists.get_mut(playlist_id) {
-            playlist.add_track(track_id);
-            info!("Added track to playlist '{}'", playlist.name);
+        let added = self.add_tracks_to_playlist(playlist_id, &[track_id])?;
+        if added == 1 {
             Ok(())
         } else {
-            Err("Playlist not found".to_string())
+            Err("Failed to add track to playlist".to_string())
         }
     }
 
@@ -70,19 +118,28 @@ impl PlaylistService {
         playlist_id: &Uuid,
         track_ids: &[Uuid],
     ) -> Result<usize, String> {
-        if let Some(playlist) = self.playlists.get_mut(playlist_id) {
-            for track_id in track_ids {
-                playlist.add_track(*track_id);
-            }
-            info!(
-                "Added {} tracks to playlist '{}'",
-                track_ids.len(),
-                playlist.name
-            );
-            Ok(track_ids.len())
-        } else {
-            Err("Playlist not found".to_string())
+        let mut next_playlist = self
+            .playlists
+            .get(playlist_id)
+            .cloned()
+            .ok_or_else(|| "Playlist not found".to_string())?;
+
+        for track_id in track_ids {
+            next_playlist.add_track(*track_id);
         }
+
+        self.store
+            .save_playlist(&next_playlist)
+            .map_err(|e| e.to_string())?;
+        let playlist_name = next_playlist.name.clone();
+        self.playlists.insert(*playlist_id, next_playlist);
+
+        info!(
+            "Added {} tracks to playlist '{}'",
+            track_ids.len(),
+            playlist_name
+        );
+        Ok(track_ids.len())
     }
 
     /// Remove a track from a playlist
@@ -91,30 +148,83 @@ impl PlaylistService {
         playlist_id: &Uuid,
         track_index: usize,
     ) -> Result<Option<Uuid>, String> {
-        if let Some(playlist) = self.playlists.get_mut(playlist_id) {
-            let result = playlist.remove_track(track_index);
-            if result.is_some() {
-                info!("Removed track from playlist '{}'", playlist.name);
-            }
-            Ok(result)
-        } else {
-            Err("Playlist not found".to_string())
+        let mut next_playlist = self
+            .playlists
+            .get(playlist_id)
+            .cloned()
+            .ok_or_else(|| "Playlist not found".to_string())?;
+        let result = next_playlist.remove_track(track_index);
+
+        self.store
+            .save_playlist(&next_playlist)
+            .map_err(|e| e.to_string())?;
+        let playlist_name = next_playlist.name.clone();
+        self.playlists.insert(*playlist_id, next_playlist);
+
+        if result.is_some() {
+            info!("Removed track from playlist '{}'", playlist_name);
         }
+
+        Ok(result)
+    }
+
+    /// Replace the full ordered track list for a playlist.
+    pub fn set_playlist_tracks(
+        &mut self,
+        playlist_id: &Uuid,
+        track_ids: Vec<Uuid>,
+    ) -> Result<(), String> {
+        let mut next_playlist = self
+            .playlists
+            .get(playlist_id)
+            .cloned()
+            .ok_or_else(|| "Playlist not found".to_string())?;
+
+        next_playlist.track_ids = track_ids;
+        next_playlist.updated_at = chrono::Utc::now();
+
+        self.store
+            .save_playlist(&next_playlist)
+            .map_err(|e| e.to_string())?;
+        self.playlists.insert(*playlist_id, next_playlist);
+        Ok(())
+    }
+
+    /// Reorder tracks in a playlist.
+    pub fn reorder_playlist_tracks(
+        &mut self,
+        playlist_id: &Uuid,
+        from_index: usize,
+        to_index: usize,
+    ) -> Result<(), String> {
+        let mut next_playlist = self
+            .playlists
+            .get(playlist_id)
+            .cloned()
+            .ok_or_else(|| "Playlist not found".to_string())?;
+
+        if from_index >= next_playlist.track_ids.len() || to_index >= next_playlist.track_ids.len() {
+            return Err("Index out of bounds".to_string());
+        }
+
+        if from_index == to_index {
+            return Ok(());
+        }
+
+        let track_id = next_playlist.track_ids.remove(from_index);
+        next_playlist.track_ids.insert(to_index, track_id);
+        next_playlist.updated_at = chrono::Utc::now();
+
+        self.store
+            .save_playlist(&next_playlist)
+            .map_err(|e| e.to_string())?;
+        self.playlists.insert(*playlist_id, next_playlist);
+        Ok(())
     }
 
     /// Get a playlist by ID
     pub fn get_playlist(&self, id: &Uuid) -> Option<&Playlist> {
         self.playlists.get(id)
-    }
-
-    /// Get a mutable reference to a playlist by ID
-    pub fn get_playlist_mut(&mut self, id: &Uuid) -> Option<&mut Playlist> {
-        self.playlists.get_mut(id)
-    }
-
-    /// Get all playlists
-    pub fn get_playlists(&self) -> Vec<&Playlist> {
-        self.playlists.values().collect()
     }
 
     /// Update playlist metadata
@@ -124,34 +234,48 @@ impl PlaylistService {
         name: Option<&str>,
         description: Option<&str>,
     ) -> Result<(), String> {
-        if let Some(playlist) = self.playlists.get_mut(id) {
-            if let Some(new_name) = name
-                && !new_name.trim().is_empty()
-                && new_name != playlist.name
-            {
-                // Check if the new name is already taken
-                let new_key = new_name.to_lowercase();
-                if self.playlist_names.contains_key(&new_key) {
-                    return Err(format!("A playlist named '{}' already exists", new_name));
-                }
+        let current = self
+            .playlists
+            .get(id)
+            .cloned()
+            .ok_or_else(|| "Playlist not found".to_string())?;
 
-                // Remove old name
-                self.playlist_names.remove(&playlist.name.to_lowercase());
-
-                // Update name
-                playlist.name = new_name.to_string();
-                self.playlist_names.insert(new_key, *id);
+        let mut next_playlist = current.clone();
+        if let Some(new_name) = name
+            && !new_name.trim().is_empty()
+            && new_name != current.name
+        {
+            let new_key = new_name.to_lowercase();
+            if self.playlist_names.get(&new_key).is_some_and(|existing| existing != id) {
+                return Err(format!("A playlist named '{}' already exists", new_name));
             }
 
-            if let Some(desc) = description {
-                playlist.description = Some(desc.to_string());
-            }
-
-            info!("Updated metadata for playlist '{}'", playlist.name);
-            Ok(())
-        } else {
-            Err("Playlist not found".to_string())
+            next_playlist.name = new_name.to_string();
+            next_playlist.updated_at = chrono::Utc::now();
         }
+
+        if let Some(desc) = description {
+            next_playlist.description = Some(desc.to_string());
+            next_playlist.updated_at = chrono::Utc::now();
+        }
+
+        self.store
+            .save_playlist(&next_playlist)
+            .map_err(|e| e.to_string())?;
+
+        self.playlist_names.remove(&current.name.to_lowercase());
+        self.playlist_names
+            .insert(next_playlist.name.to_lowercase(), *id);
+        let playlist_name = next_playlist.name.clone();
+        self.playlists.insert(*id, next_playlist);
+
+        info!("Updated metadata for playlist '{}'", playlist_name);
+        Ok(())
+    }
+
+    /// Get all playlists
+    pub fn get_playlists(&self) -> Vec<&Playlist> {
+        self.playlists.values().collect()
     }
 
     /// Find a playlist by name (case-insensitive)
@@ -170,22 +294,131 @@ impl PlaylistService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_create_playlist_returns_same_id_as_playlist_record() {
+        let temp_dir = tempdir().unwrap();
+        let db_path = temp_dir.path().join("library.sqlite");
+        let mut service = PlaylistService::open(&db_path).unwrap();
+
+        let playlist_id = service.create_playlist("Road Trip").unwrap();
+        let playlist = service.get_playlist(&playlist_id).unwrap();
+
+        assert_eq!(playlist.id, playlist_id);
+    }
+
+    #[test]
+    fn test_playlist_data_persists_across_service_reopen() {
+        let temp_dir = tempdir().unwrap();
+        let db_path = temp_dir.path().join("library.sqlite");
+        let track_ids = vec![Uuid::new_v4(), Uuid::new_v4()];
+
+        let playlist_id = {
+            let mut service = PlaylistService::open(&db_path).unwrap();
+            let playlist_id = service.create_playlist("After Hours").unwrap();
+            let added = service.add_tracks_to_playlist(&playlist_id, &track_ids).unwrap();
+            assert_eq!(added, track_ids.len());
+            playlist_id
+        };
+
+        let reopened = PlaylistService::open(&db_path).unwrap();
+        let playlist = reopened.get_playlist(&playlist_id).unwrap();
+
+        assert_eq!(playlist.name, "After Hours");
+        assert_eq!(playlist.track_ids, track_ids);
+    }
+
+    #[test]
+    fn test_update_playlist_metadata_persists_across_service_reopen() {
+        let temp_dir = tempdir().unwrap();
+        let db_path = temp_dir.path().join("library.sqlite");
+
+        let playlist_id = {
+            let mut service = PlaylistService::open(&db_path).unwrap();
+            let playlist_id = service.create_playlist("Old Name").unwrap();
+            service
+                .update_playlist_metadata(&playlist_id, Some("New Name"), Some("Late-night mix"))
+                .unwrap();
+            playlist_id
+        };
+
+        let reopened = PlaylistService::open(&db_path).unwrap();
+        let playlist = reopened.get_playlist(&playlist_id).unwrap();
+        assert_eq!(playlist.name, "New Name");
+        assert_eq!(playlist.description.as_deref(), Some("Late-night mix"));
+    }
+
+    #[test]
+    fn test_set_playlist_tracks_persists_across_service_reopen() {
+        let temp_dir = tempdir().unwrap();
+        let db_path = temp_dir.path().join("library.sqlite");
+        let track_ids = vec![Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
+
+        let playlist_id = {
+            let mut service = PlaylistService::open(&db_path).unwrap();
+            let playlist_id = service.create_playlist("Queue Draft").unwrap();
+            service.set_playlist_tracks(&playlist_id, track_ids.clone()).unwrap();
+            playlist_id
+        };
+
+        let reopened = PlaylistService::open(&db_path).unwrap();
+        let playlist = reopened.get_playlist(&playlist_id).unwrap();
+        assert_eq!(playlist.track_ids, track_ids);
+    }
+
+    #[test]
+    fn test_reorder_playlist_tracks_persists_across_service_reopen() {
+        let temp_dir = tempdir().unwrap();
+        let db_path = temp_dir.path().join("library.sqlite");
+        let track_a = Uuid::new_v4();
+        let track_b = Uuid::new_v4();
+        let track_c = Uuid::new_v4();
+
+        let playlist_id = {
+            let mut service = PlaylistService::open(&db_path).unwrap();
+            let playlist_id = service.create_playlist("Commute").unwrap();
+            service
+                .set_playlist_tracks(&playlist_id, vec![track_a, track_b, track_c])
+                .unwrap();
+            service.reorder_playlist_tracks(&playlist_id, 2, 0).unwrap();
+            playlist_id
+        };
+
+        let reopened = PlaylistService::open(&db_path).unwrap();
+        let playlist = reopened.get_playlist(&playlist_id).unwrap();
+        assert_eq!(playlist.track_ids, vec![track_c, track_a, track_b]);
+    }
+
+    #[test]
+    fn test_delete_playlist_persists_across_service_reopen() {
+        let temp_dir = tempdir().unwrap();
+        let db_path = temp_dir.path().join("library.sqlite");
+
+        let playlist_id = {
+            let mut service = PlaylistService::open(&db_path).unwrap();
+            let playlist_id = service.create_playlist("Disposable").unwrap();
+            service.delete_playlist(&playlist_id).unwrap();
+            playlist_id
+        };
+
+        let reopened = PlaylistService::open(&db_path).unwrap();
+        assert!(reopened.get_playlist(&playlist_id).is_none());
+    }
+
     #[test]
     fn test_create_playlist() {
         let mut service = PlaylistService::default();
 
-        // Create a new playlist
         let result = service.create_playlist("My Playlist");
         assert!(result.is_ok());
 
         let _playlist_id = result.unwrap();
         assert_eq!(service.count(), 1);
 
-        // Try to create a duplicate playlist
         let result = service.create_playlist("My Playlist");
         assert!(result.is_err());
 
-        // Try to create a playlist with empty name
         let result = service.create_playlist("");
         assert!(result.is_err());
     }
@@ -196,23 +429,18 @@ mod tests {
         let playlist_id = service.create_playlist("Test").unwrap();
         let track_id = Uuid::new_v4();
 
-        // Add a track
         assert!(service.add_to_playlist(&playlist_id, track_id).is_ok());
 
-        // Check track count
         let playlist = service.get_playlist(&playlist_id).unwrap();
         assert_eq!(playlist.track_count(), 1);
 
-        // Remove the track
         let result = service.remove_from_playlist(&playlist_id, 0);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), Some(track_id));
 
-        // Check track count after removal
         let playlist = service.get_playlist(&playlist_id).unwrap();
         assert_eq!(playlist.track_count(), 0);
 
-        // Try to remove non-existent track
         let result = service.remove_from_playlist(&playlist_id, 0);
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
@@ -236,7 +464,6 @@ mod tests {
         let mut service = PlaylistService::default();
         let playlist_id = service.create_playlist("Old Name").unwrap();
 
-        // Update name
         assert!(
             service
                 .update_playlist_metadata(&playlist_id, Some("New Name"), Some("A test playlist"))
@@ -247,7 +474,6 @@ mod tests {
         assert_eq!(playlist.name, "New Name");
         assert_eq!(playlist.description, Some("A test playlist".to_string()));
 
-        // Try to update to existing name
         let another_id = service.create_playlist("Another Playlist").unwrap();
         let result = service.update_playlist_metadata(&another_id, Some("New Name"), None);
         assert!(result.is_err());

--- a/src-tauri/src/services/playlist/store.rs
+++ b/src-tauri/src/services/playlist/store.rs
@@ -1,0 +1,191 @@
+use std::path::Path;
+
+use anyhow::{Context, Result, anyhow};
+use chrono::{TimeZone, Utc};
+use rusqlite::{Connection, params};
+use uuid::Uuid;
+
+use crate::models::Playlist;
+
+pub struct PlaylistStore {
+    conn: Connection,
+}
+
+impl PlaylistStore {
+    pub fn open(path: &Path) -> Result<Self> {
+        let mut conn = Connection::open(path).context("Failed to open playlist database")?;
+        initialize_schema(&mut conn)?;
+        Ok(Self { conn })
+    }
+
+    pub fn open_in_memory() -> Result<Self> {
+        let mut conn = Connection::open_in_memory().context("Failed to open in-memory playlist database")?;
+        initialize_schema(&mut conn)?;
+        Ok(Self { conn })
+    }
+
+    pub fn load_all(&self) -> Result<Vec<Playlist>> {
+        let mut stmt = self.conn.prepare(
+            r#"
+            SELECT id, name, description, date_added, COALESCE(updated_at, date_added) AS updated_at
+            FROM playlists
+            ORDER BY lower(name)
+            "#,
+        )?;
+
+        let mut rows = stmt.query([])?;
+        let mut playlists = Vec::new();
+        while let Some(row) = rows.next()? {
+            let id_text: String = row.get("id")?;
+            let id = Uuid::parse_str(&id_text)
+                .with_context(|| format!("Invalid playlist UUID stored in database: {id_text}"))?;
+            let created_at_ts: i64 = row.get("date_added")?;
+            let updated_at_ts: i64 = row.get("updated_at")?;
+
+            let mut playlist = Playlist {
+                id,
+                name: row.get("name")?,
+                description: row.get("description")?,
+                track_ids: self.load_track_ids(&id)?,
+                artwork: None,
+                created_at: timestamp_to_utc(created_at_ts)?,
+                updated_at: timestamp_to_utc(updated_at_ts)?,
+            };
+
+            if playlist.updated_at < playlist.created_at {
+                playlist.updated_at = playlist.created_at;
+            }
+
+            playlists.push(playlist);
+        }
+
+        Ok(playlists)
+    }
+
+    pub fn save_playlist(&mut self, playlist: &Playlist) -> Result<()> {
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            r#"
+            INSERT INTO playlists (id, name, description, date_added, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            ON CONFLICT(id) DO UPDATE SET
+                name = excluded.name,
+                description = excluded.description,
+                updated_at = excluded.updated_at
+            "#,
+            params![
+                playlist.id.to_string(),
+                playlist.name,
+                playlist.description,
+                playlist.created_at.timestamp(),
+                playlist.updated_at.timestamp(),
+            ],
+        )?;
+
+        tx.execute(
+            "DELETE FROM playlist_tracks WHERE playlist_id = ?1",
+            params![playlist.id.to_string()],
+        )?;
+
+        for (position, track_id) in playlist.track_ids.iter().enumerate() {
+            tx.execute(
+                r#"
+                INSERT INTO playlist_tracks (playlist_id, track_id, position)
+                VALUES (?1, ?2, ?3)
+                "#,
+                params![playlist.id.to_string(), track_id.to_string(), position as i64],
+            )?;
+        }
+
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn delete_playlist(&self, playlist_id: &Uuid) -> Result<()> {
+        self.conn.execute(
+            "DELETE FROM playlist_tracks WHERE playlist_id = ?1",
+            params![playlist_id.to_string()],
+        )?;
+        self.conn.execute(
+            "DELETE FROM playlists WHERE id = ?1",
+            params![playlist_id.to_string()],
+        )?;
+        Ok(())
+    }
+
+    fn load_track_ids(&self, playlist_id: &Uuid) -> Result<Vec<Uuid>> {
+        let mut stmt = self.conn.prepare(
+            r#"
+            SELECT track_id
+            FROM playlist_tracks
+            WHERE playlist_id = ?1
+            ORDER BY position ASC
+            "#,
+        )?;
+
+        let mut rows = stmt.query(params![playlist_id.to_string()])?;
+        let mut track_ids = Vec::new();
+        while let Some(row) = rows.next()? {
+            let track_id_text: String = row.get(0)?;
+            let track_id = Uuid::parse_str(&track_id_text)
+                .with_context(|| format!("Invalid track UUID stored in database: {track_id_text}"))?;
+            track_ids.push(track_id);
+        }
+
+        Ok(track_ids)
+    }
+}
+
+fn initialize_schema(conn: &mut Connection) -> Result<()> {
+    conn.pragma_update(None, "foreign_keys", "ON")?;
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS playlists (
+            id TEXT PRIMARY KEY NOT NULL,
+            name TEXT NOT NULL UNIQUE,
+            description TEXT,
+            date_added INTEGER NOT NULL,
+            updated_at INTEGER
+        );
+
+        CREATE TABLE IF NOT EXISTS playlist_tracks (
+            playlist_id TEXT NOT NULL,
+            track_id TEXT NOT NULL,
+            position INTEGER NOT NULL,
+            PRIMARY KEY (playlist_id, position)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_playlist_tracks_playlist_position
+            ON playlist_tracks (playlist_id, position);
+        "#,
+    )?;
+
+    ensure_updated_at_column(conn)?;
+    Ok(())
+}
+
+fn ensure_updated_at_column(conn: &Connection) -> Result<()> {
+    let has_updated_at = conn
+        .prepare("PRAGMA table_info(playlists)")?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<Vec<_>, _>>()?
+        .into_iter()
+        .any(|name| name == "updated_at");
+
+    if !has_updated_at {
+        conn.execute("ALTER TABLE playlists ADD COLUMN updated_at INTEGER", [])?;
+    }
+
+    conn.execute(
+        "UPDATE playlists SET updated_at = date_added WHERE updated_at IS NULL",
+        [],
+    )?;
+
+    Ok(())
+}
+
+fn timestamp_to_utc(value: i64) -> Result<chrono::DateTime<Utc>> {
+    Utc.timestamp_opt(value, 0)
+        .single()
+        .ok_or_else(|| anyhow!("Invalid UTC timestamp stored in playlist database: {value}"))
+}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -133,7 +133,7 @@
     {:else if route.name === "settings"}
       <SettingsView on:refreshLibrary={loadLibrary} on:refreshPlaylists={loadPlaylists} />
     {:else if route.name === "playlistDetail"}
-      <PlaylistDetailView playlistId={route.id} />
+      <PlaylistDetailView playlistId={route.id} on:refreshPlaylists={loadPlaylists} />
     {/if}
   </main>
 

--- a/src/lib/views/PlaylistDetailView.svelte
+++ b/src/lib/views/PlaylistDetailView.svelte
@@ -26,7 +26,10 @@
 
   export let playlistId: string | null = null;
 
-  const dispatch = createEventDispatcher<{ playTrack: { track: Track } }>();
+  const dispatch = createEventDispatcher<{
+    playTrack: { track: Track };
+    refreshPlaylists: void;
+  }>();
 
   let playlist: Playlist | null = null;
   let tracks: Track[] = [];
@@ -135,6 +138,7 @@
     try {
       await updatePlaylistMetadata(playlistId, trimmed, playlist.description ?? null);
       await loadPlaylist(playlistId, { force: true });
+      dispatch('refreshPlaylists');
     } catch (err) {
       console.error('Failed to rename playlist:', err);
       alert('Could not rename playlist.');

--- a/src/tests/app-shell-wiring.test.ts
+++ b/src/tests/app-shell-wiring.test.ts
@@ -59,6 +59,11 @@ vi.mock('../lib/player/BottomPlayerBar.svelte', async () => {
   return { default: module.default };
 });
 
+vi.mock('../lib/views/PlaylistDetailView.svelte', async () => {
+  const module = await import('./stubs/PlaylistDetailViewSpy.svelte');
+  return { default: module.default };
+});
+
 import App from '../App.svelte';
 
 type SongsViewSpyWindow = Window & {
@@ -86,6 +91,7 @@ describe('App songs-shell wiring', () => {
     cleanup();
     delete spyWindow.__songsViewSpyProps;
     window.location.hash = '';
+    appShellMock.loadPlaylists.mockClear();
   });
 
   it('passes playlists and refreshPlaylists into SongsView on the songs route', async () => {
@@ -101,5 +107,16 @@ describe('App songs-shell wiring', () => {
 
     expect(spyWindow.__songsViewSpyProps?.playlists).toEqual(appShellMock.playlistsValue);
     expect(spyWindow.__songsViewSpyProps?.refreshPlaylists).toBe(appShellMock.loadPlaylists);
+  });
+
+  it('refreshes app-shell playlists when PlaylistDetailView dispatches refreshPlaylists', async () => {
+    window.location.hash = '#/playlists/playlist-1';
+
+    render(App);
+
+    const refreshTrigger = await screen.findByTestId('playlist-detail-view-spy');
+    await refreshTrigger.click();
+
+    expect(appShellMock.loadPlaylists).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/tests/playlist-detail-view.test.ts
+++ b/src/tests/playlist-detail-view.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const playlistApiMock = vi.hoisted(() => ({
+  getPlaylist: vi.fn(),
+  getPlaylistTracks: vi.fn(),
+  removeFromPlaylist: vi.fn(),
+  updatePlaylistMetadata: vi.fn(),
+}));
+
+const playbackApiMock = vi.hoisted(() => ({
+  playTrack: vi.fn(),
+  setQueue: vi.fn(),
+}));
+
+vi.mock('../lib/api/playlist', () => ({
+  getPlaylist: playlistApiMock.getPlaylist,
+  getPlaylistTracks: playlistApiMock.getPlaylistTracks,
+  removeFromPlaylist: playlistApiMock.removeFromPlaylist,
+  updatePlaylistMetadata: playlistApiMock.updatePlaylistMetadata,
+}));
+
+vi.mock('../lib/api/playback', () => ({
+  playTrack: playbackApiMock.playTrack,
+  setQueue: playbackApiMock.setQueue,
+}));
+
+import PlaylistDetailView from '../lib/views/PlaylistDetailView.svelte';
+import type { Playlist, Track } from '../lib/types';
+
+const basePlaylist: Playlist = {
+  id: 'playlist-1',
+  name: 'After Hours',
+  description: 'Late-night rotation',
+  track_ids: ['track-1'],
+  created_at: '2026-03-01T00:00:00.000Z',
+  updated_at: '2026-03-01T00:00:00.000Z',
+};
+
+const tracks: Track[] = [
+  {
+    id: 'track-1',
+    title: 'Signal Bloom',
+    duration: 180,
+    path: '/music/signal-bloom.flac',
+    size: 123,
+    format: 'flac',
+    bitrate: 320,
+    sample_rate: 48_000,
+    channels: 2,
+    play_count: 0,
+    date_added: '2026-03-01T00:00:00.000Z',
+    artist_name: 'Night Engines',
+    album_title: 'Late Transit',
+  },
+];
+
+describe('PlaylistDetailView', () => {
+  beforeEach(() => {
+    playlistApiMock.getPlaylist.mockReset();
+    playlistApiMock.getPlaylistTracks.mockReset();
+    playlistApiMock.removeFromPlaylist.mockReset().mockResolvedValue(null);
+    playlistApiMock.updatePlaylistMetadata.mockReset().mockResolvedValue(undefined);
+    playbackApiMock.playTrack.mockReset().mockResolvedValue(undefined);
+    playbackApiMock.setQueue.mockReset().mockResolvedValue(undefined);
+
+    playlistApiMock.getPlaylist
+      .mockResolvedValueOnce(basePlaylist)
+      .mockResolvedValueOnce({
+        ...basePlaylist,
+        name: 'Renamed Playlist',
+        updated_at: '2026-03-02T00:00:00.000Z',
+      });
+    playlistApiMock.getPlaylistTracks.mockResolvedValue(tracks);
+
+    vi.stubGlobal('alert', vi.fn());
+    vi.stubGlobal('prompt', vi.fn(() => 'Renamed Playlist'));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('dispatches refreshPlaylists after a successful rename', async () => {
+    const refreshHandler = vi.fn();
+    render(PlaylistDetailView, {
+      props: { playlistId: 'playlist-1' },
+      events: { refreshPlaylists: refreshHandler },
+    });
+
+    await screen.findByRole('heading', { name: 'After Hours' });
+    await fireEvent.click(screen.getByRole('button', { name: /rename/i }));
+
+    await waitFor(() => {
+      expect(playlistApiMock.updatePlaylistMetadata).toHaveBeenCalledWith(
+        'playlist-1',
+        'Renamed Playlist',
+        'Late-night rotation',
+      );
+      expect(refreshHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/tests/stubs/PlaylistDetailViewSpy.svelte
+++ b/src/tests/stubs/PlaylistDetailViewSpy.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+
+  export let playlistId: string | null = null;
+
+  const dispatch = createEventDispatcher<{
+    refreshPlaylists: void;
+  }>();
+</script>
+
+<button
+  data-testid="playlist-detail-view-spy"
+  on:click={() => dispatch('refreshPlaylists')}
+>
+  playlist-detail:{playlistId}
+</button>


### PR DESCRIPTION
## 背景
同步到最新 `main` 后，Songs 列表批量操作主体已经随 PR #13 合入，因此本 PR **不再处理 Songs 批量操作 UI 本身**，而是聚焦 issue #14 当前真正的阻塞点：playlist 域仍是内存态，且存在状态一致性问题。

本 PR 主要解决这些问题：
- `PlaylistService` 仍是内存 `HashMap`，应用重启后歌单状态不能可靠保留
- `create_playlist()` 返回的 id 与 `Playlist::new()` 内部生成的 `playlist.id` 可能不一致
- `set / reorder / delete` 等 mutation 仍有 API 层直接改内存的路径
- `PlaylistDetailView` 成功修改后，app shell 中的 playlist 列表还没有刷新闭环

## 本次改动
- 新增 `src-tauri/src/services/playlist/store.rs`
  - 为 playlist 提供独立的 SQLite 持久化层
  - 启动时从数据库加载 playlist 与 track 顺序
- 调整 `PlaylistService`
  - 改为通过 store 持久化并在启动时 hydrate 内存状态
  - 让 `create / add / remove / set / reorder / update / delete` 统一走 service 持久化入口
- 修复 playlist id 一致性
  - 在 `Playlist` 模型中增加 `with_id()`
  - `create_playlist()` 只生成一次 id，并同时用于 service key 与 `Playlist.id`
- 收口 playlist mutation ownership
  - `src-tauri/src/api/playlist/mod.rs` 中的 `set_playlist_tracks` / `reorder_playlist_tracks` 不再直接修改内存结构，而是转调 service
- 补齐 playlist detail -> app shell refresh
  - `PlaylistDetailView.svelte` 成功 rename 后派发 `refreshPlaylists`
  - `App.svelte` 接回 `loadPlaylists`
- 增加回归测试
  - Rust：验证 id 一致性、跨 reopen 持久化、rename / set / reorder / delete 持久化
  - Frontend：验证 playlist detail 的 refresh 事件，以及 App 对该事件的接线

## Review Focus
建议 reviewer 重点看：
1. `src-tauri/src/services/playlist/mod.rs` 与 `store.rs` 的状态 ownership 是否清晰
2. playlist mutation 是否都已从 API 层收口回 service
3. `PlaylistDetailView` -> `App` 的 refresh 接线是否足够小且稳定
4. 新增测试是否覆盖了这次行为变化的关键路径

## 非目标
本 PR 明确**不包含**：
- Songs 列表批量操作 UI 的再开发
- `add_tracks_to_playlist` 返回结构的重新设计
- 歌单导入 / 导出
- 智能歌单或歌单封面能力

## Test Plan
- [x] `cargo test --manifest-path ./src-tauri/Cargo.toml -- --nocapture`
- [x] `npm --prefix ./src run test`
- [x] `npm --prefix ./src run check`

Fixes #14

