### PR TITLE
spec: 队列与 Now Playing 体验完善（issue #21）

### DIFF
--- a/docs/superpowers/specs/2026-03-30-queue-now-playing-design.md
+++ b/docs/superpowers/specs/2026-03-30-queue-now-playing-design.md
@@ -66,6 +66,7 @@
 ### 4.2 点击队列项 → 跳转播放
 
 - 行为：点击队列项会开始播放该项。
+- 若点击的是当前播放项：无动作（no-op），避免误触重播。
 - 语义约束：
   - 不通过 `set_queue` 来“重置队列 + 播放”，避免重置 `current_index/history` 造成行为偏差。
   - 推荐直接调用既有 `play(track)`（后端会在 `PlayQueue` 中选中该 track_id）；或新增更窄的 `select_queue_track(track_id)` 命令（见 §5）。
@@ -107,7 +108,7 @@
    - 行为：从队列移除该项
    - 若 track_id 不存在：返回 Err
    - 约束：若 track_id == 当前播放 track_id，应返回 Err（保护性拒绝）
-   - 约束（MVP）：队列内 `track.id` 视为唯一；若出现重复，默认删除第一个匹配项（best-effort）
+   - 约束（MVP）：队列内 `track.id` 必须唯一（不支持重复项）；若出现重复，remove 行为为 best-effort（删除第一个匹配项）
    - 输出：`Result<(), String>`
 
 2) `clear_queue()`


### PR DESCRIPTION
Refs #21

## 本 PR 做什么

提交 #21 的设计稿（spec），用于进入后续 writing-plans 与实现。

Spec 路径：
- `docs/superpowers/specs/2026-03-30-queue-now-playing-design.md`

## 关键决策（已锁定）
- 队列管理闭环（MVP2 P0）：当前项标识 + 点击跳转播放 + 移除单项 + 清空队列（不做拖拽重排）。
- “清空队列”：不打断当前播放；队列列表清空后显示空态文案。
- 点击队列中的“当前播放项”：无动作（避免误触重播）。
- 队列内 `track.id` 约定唯一（不支持重复项）；若异常重复，remove 为 best-effort（删第一个匹配项）。
- 移除操作不允许针对当前播放项（UI 禁用 + 后端拒绝）。

## 与 #20 的分工
- #20 负责 Now Playing 页面骨架与歌词交互合同；
- #21 负责队列能力本身，并产出可复用队列组件供 #20 的 Queue Tab 使用。
