### PR TITLE
fix(deps): update rand 0.8 lockfile

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3399,7 +3399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3409,7 +3409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3876,9 +3876,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4311,7 +4311,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",


### PR DESCRIPTION
## Summary
- Updates the locked transitive `rand` 0.8.x package from `0.8.5` to the patched `0.8.6` release for RUSTSEC-2026-0097.
- Leaves the remaining `rand 0.7.3` entry unchanged because it is pulled through a build-time Tauri HTML/CSS parsing chain: `tauri-utils -> kuchikiki -> selectors -> phf_codegen -> phf_generator -> rand`.
- Verified the remaining `rand 0.7.3` feature graph does not enable the advisory-triggering `log` feature; it only enables the default/std/small_rng/getrandom/libc/rand_pcg feature set.

## Verification
- `CARGO_HOME=/tmp/cargo-home cargo tree --manifest-path src-tauri/Cargo.toml -i rand@0.8.6`
- `CARGO_HOME=/tmp/cargo-home cargo tree --manifest-path src-tauri/Cargo.toml -e features -i rand@0.7.3`
- `HOME=/tmp/myMusicPlayer-rs-qa-home RUSTUP_HOME=/Users/zhangxing/.rustup CARGO_HOME=/tmp/cargo-home MUSIC_PLAYER_RS_DATA_DIR=/tmp/myMusicPlayer-rs-qa-data MUSIC_PLAYER_RS_CONFIG_DIR=/tmp/myMusicPlayer-rs-qa-config npm_config_cache=/tmp/npm-cache just qa`